### PR TITLE
Disable the systemd-resolve configuration for Fedora33

### DIFF
--- a/02_provision_libvirt_resources.yml
+++ b/02_provision_libvirt_resources.yml
@@ -16,6 +16,19 @@
         state: present
       register: output_masters
 
+    - name: Disable systemd-resolve
+      service:
+        name: systemd-resolved
+        state: stop
+        enabled: false
+      when: ansible_distribution == 'Fedora' and ansible_distribution_major_version == '33'
+
+    - name: Remove the resolve.conf file
+      file:
+        path: /etc/resolve.conf
+        state: absent
+      when: ansible_distribution == 'Fedora' and ansible_distribution_major_version == '33'
+
     - name: Configure NetworkManager for local DNS
       copy:
         src: files/localdns.conf

--- a/02_provision_libvirt_resources.yml
+++ b/02_provision_libvirt_resources.yml
@@ -19,13 +19,13 @@
     - name: Disable systemd-resolve
       service:
         name: systemd-resolved
-        state: stop
+        state: stopped
         enabled: false
       when: ansible_distribution == 'Fedora' and ansible_distribution_major_version == '33'
 
     - name: Remove the resolve.conf file
       file:
-        path: /etc/resolve.conf
+        path: /etc/resolv.conf
         state: absent
       when: ansible_distribution == 'Fedora' and ansible_distribution_major_version == '33'
 


### PR DESCRIPTION
Disable the systemd-resolved.service and removed the original /etc/resolv.conf on Fedora33