### PR TITLE
Fixed cilium dead pods

### DIFF
--- a/02_prepare_setup.yml
+++ b/02_prepare_setup.yml
@@ -85,7 +85,7 @@
 
     - name: Download Ubuntu image
       get_url:
-        url: "{{ ubuntu_impish.cloud_image if kubernetes_version.1 | int > 20 else ubuntu.cloud_image }}"
+        url: "{{ ubuntu_jammy.cloud_image if kubernetes_version.1 | int > 20 else ubuntu.cloud_image }}"
         dest: /tmp/{{ image_name }}.qcow2
         mode: 0777
       when: k8s.cluster_os == 'Ubuntu'

--- a/10_container_runtimes.yml
+++ b/10_container_runtimes.yml
@@ -55,6 +55,22 @@
             - key: net.bridge.bridge-nf-call-iptables
               value: 1
 
+        - name: Fix dead traffic on Systemd 245+ for cilium
+          block:
+          - name: Setup sysctl
+            copy:
+              dest: /etc/sysctl.d/99-restore-cilium-traffic.conf
+              content: "net.ipv4.conf.lxc*.rp_filter = 0"        
+
+          - name: Ensure sysctl is restarted
+            service:
+              name: systemd-sysctl
+              state: restarted
+          when:
+            - kubernetes_version.1 | int >= 20
+            - k8s.cluster_os == "Ubuntu"
+            - k8s.network.cni_plugin == "cilium"
+
     - name: Configure docker on a Ubuntu machine
       block: 
         - name: Ensure required packages are present
@@ -197,12 +213,32 @@
               - cri-o
               - cri-o-runc
             state: latest
-          when: k8s.cluster_os == 'Ubuntu'
+          when: 
+            - k8s.cluster_os == 'Ubuntu'
+            - kubernetes_version.1 | int <= 20
+
+        - name: Ensure cri-o is installed - Ubuntu
+          apt:
+            name:
+              - cri-o
+              - crun
+            state: latest
+          when: 
+            - k8s.cluster_os == 'Ubuntu'
+            - kubernetes_version.1 | int > 20
 
         - name: Fire crio-conf template 
           template: 
             src: templates/crio.conf.j2
             dest: /etc/crio/crio.conf
+
+        - name: Fire crio-conf template
+          template:
+            src: templates/crio.conf.crun.j2
+            dest: /etc/crio/crio.conf.d/01-crio-runc.conf
+          when:
+            - k8s.cluster_os == 'Ubuntu'
+            - kubernetes_version.1 | int > 20
 
         - name: Remove example CNI configs
           file:

--- a/group_vars/k8s_nodes/vars.yml
+++ b/group_vars/k8s_nodes/vars.yml
@@ -33,11 +33,11 @@ docker:
 
 crio:
   ubuntu:
-    libcontainers_repo: deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_{{ '21.10' if hostvars[groups['masters'][0]].kubernetes_version.1 | int > 20 else '20.04' }}/ /
-    libcontainers_key: https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_{{ '21.10' if hostvars[groups['masters'][0]].kubernetes_version.1 | int > 20 else '20.04' }}/Release.key
+    libcontainers_repo: deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_{{ '22.04' if hostvars[groups['masters'][0]].kubernetes_version.1 | int > 20 else '20.04' }}/ /
+    libcontainers_key: https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_{{ '22.04' if hostvars[groups['masters'][0]].kubernetes_version.1 | int > 20 else '20.04' }}/Release.key
     libcontainers_keyring: /etc/apt/trusted.gpg.d/libcontainers.gpg
-    crio_repo: deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/{{ vars["k8s"]["cluster_version"] }}/xUbuntu_{{ '21.10' if hostvars[groups['masters'][0]].kubernetes_version.1 | int > 20 else '20.04' }}/ /
-    crio_key: https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:/{{ vars["k8s"]["cluster_version"] }}/xUbuntu_{{ '21.10' if hostvars[groups['masters'][0]].kubernetes_version.1 | int > 20 else '20.04' }}/Release.key
+    crio_repo: deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/{{ vars["k8s"]["cluster_version"] }}/xUbuntu_{{ '22.04' if hostvars[groups['masters'][0]].kubernetes_version.1 | int > 20 else '20.04' }}/ /
+    crio_key: https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:/{{ vars["k8s"]["cluster_version"] }}/xUbuntu_{{ '22.04' if hostvars[groups['masters'][0]].kubernetes_version.1 | int > 20 else '20.04' }}/Release.key
     crio_keyring: /etc/apt/trusted.gpg.d/libcontainers-cri-o.gpg
   centos:
     libcontainers_repo: http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_8_Stream/devel:kubic:libcontainers:stable.repo

--- a/group_vars/vm_host/vars.yml
+++ b/group_vars/vm_host/vars.yml
@@ -8,8 +8,8 @@ centos:
   cloud_image: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20220125.1.x86_64.qcow2
 ubuntu:
   cloud_image: https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.img
-ubuntu_impish:
-  cloud_image: https://cloud-images.ubuntu.com/releases/impish/release/ubuntu-21.10-server-cloudimg-amd64.img
+ubuntu_jammy:
+  cloud_image: https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-amd64.img
 
 libvirt:
   storage:
@@ -79,7 +79,7 @@ cni_plugins:
     chart:
       name: cilium
       ref: cilium/cilium
-      version: 1.11.2
+      version: 1.11.4
       url: https://helm.cilium.io/
 
 ingress:

--- a/group_vars/vm_host/vars.yml
+++ b/group_vars/vm_host/vars.yml
@@ -2,7 +2,7 @@
 ##        Infra related         ##
 ##################################
 
-terraform_url: https://releases.hashicorp.com/terraform/1.1.6/terraform_1.1.6_linux_amd64.zip
+terraform_url: https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_amd64.zip
 image_name: OS-GenericCloud
 centos:
   cloud_image: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20220125.1.x86_64.qcow2

--- a/group_vars/vm_host/vars.yml
+++ b/group_vars/vm_host/vars.yml
@@ -100,7 +100,7 @@ ingress:
       ref: haproxytech/kubernetes-ingress
 
 helm:
-  helm_installer: https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz
+  helm_installer: https://get.helm.sh/helm-v3.8.2-linux-amd64.tar.gz
 
 rook:
   operator:

--- a/templates/crio.conf.crun.j2
+++ b/templates/crio.conf.crun.j2
@@ -1,0 +1,4 @@
+[crio.runtime.runtimes.crun]
+runtime_path = "/usr/bin/crun"
+runtime_type = "oci"
+runtime_root = "/run/crun"

--- a/templates/crio.conf.j2
+++ b/templates/crio.conf.j2
@@ -2,6 +2,9 @@
 [crio.runtime]
 selinux = false
 cgroup_manager="systemd"
+{% if k8s.cluster_os == "Ubuntu" and hostvars[inventory_hostname]['kubernetes_version'][1] | int > 20 %}
+default_runtime = "crun"
+{% endif %}
 default_capabilities = [
  "CHOWN",
  "DAC_OVERRIDE",


### PR DESCRIPTION
Fixes:
- Bumped Ubuntu version to 22.04LTS
- Due to ubuntu version being bumped to 22.04LTS, systemd breaks pods traffic when cilium is installed (https://docs.cilium.io/en/v1.11/operations/system_requirements/#linux-distribution-compatibility-matrix). 
- Default container runtime on Ubuntu 22.04 is crun
- Updated cilium chart to 1.11.4
- Updated terraform to 1.1.9
- Updated helm to 3.8.2