### PR TITLE
Fix DNS on Ubuntu

### DIFF
--- a/03_provision_libvirt_resources.yml
+++ b/03_provision_libvirt_resources.yml
@@ -20,8 +20,8 @@
 
     - name: Take care of systemd-resolved on F33 and Ubuntu hosts
       when:
-        (ansible_distribution == 'Fedora' and ansible_distribution_major_version | int < 33) or
-        (ansible_distribution == 'Ubuntu')
+        (ansible_distribution == 'Fedora' and ansible_distribution_major_version | int > 33) or
+        (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int > 18)
       block:
         - name: Ensure systemd-resolved config dir is present
           ansible.builtin.file:

--- a/03_provision_libvirt_resources.yml
+++ b/03_provision_libvirt_resources.yml
@@ -21,7 +21,7 @@
     - name: Take care of systemd-resolved on F33 and Ubuntu hosts
       when:
         (ansible_distribution == 'Fedora' and ansible_distribution_major_version | int < 33) or
-        (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int < 18)
+        (ansible_distribution == 'Ubuntu')
       block:
         - name: Ensure systemd-resolved config dir is present
           ansible.builtin.file:


### PR DESCRIPTION
Removes the Ubuntu version constraint, since systemd-resolved also needs to be configured for newer versions (like `23.10`). 

This might also be applicable to Fedora, but I am not sufficiently familiar with that system to make any further changes in this PR.

Fixes #59